### PR TITLE
Migrate column types to allow longer questions/reminders

### DIFF
--- a/src/__tests__/db.test.tsx
+++ b/src/__tests__/db.test.tsx
@@ -21,4 +21,48 @@ describe("Database operations", () => {
         .then(() => knex.migrate.rollback(undefined, true)),
     20000,
   );
+
+  describe("Test specific models", () => {
+    beforeAll(() => {
+      // Ensure test database is initialized before an tests
+      return knex.migrate.rollback().then(() => knex.migrate.latest());
+    }, 20000);
+
+    beforeEach(() => {
+      // Reset contents of the test database
+      return knex.seed.run();
+    });
+
+    test("Can create a reminder with a long description", async () => {
+      const [{ id: roomId }] = await knex("Room")
+        .select("id")
+        .where("visibleId", "a418c099-4114-4c55-8a5b-4a142c2b26d1");
+
+      const reminder = {
+        roomId,
+        title: "Test Reminder",
+        description: "This is a long description".repeat(100),
+        start_time: new Date(Date.now() - 1 * 60 * 60 * 1000),
+        end_time: new Date(Date.now() + 1 * 60 * 60 * 1000),
+      };
+
+      const [id] = await knex("Reminder").insert(reminder).returning("id");
+      expect(id).toBeDefined();
+    });
+
+    test("Can create a long question", async () => {
+      const [{ id: roomId }] = await knex("Room")
+        .select("id")
+        .where("visibleId", "a418c099-4114-4c55-8a5b-4a142c2b26d1");
+
+      const question = {
+        roomId,
+        question: "This is a long question".repeat(100),
+        anonymous: true,
+      };
+
+      const [id] = await knex("Question").insert(question).returning("id");
+      expect(id).toBeDefined();
+    });
+  });
 });

--- a/src/knex/migrations/20240216152644_allow_longer_text_fields.ts
+++ b/src/knex/migrations/20240216152644_allow_longer_text_fields.ts
@@ -1,0 +1,22 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("Reminder", (table) => {
+    // Allow variable length text fields (default is 255)
+    table.specificType("description", "varchar").alter();
+  });
+  await knex.schema.alterTable("Question", (table) => {
+    // Allow variable length text fields (default is 255)
+    table.specificType("question", "varchar").alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Reset original field types
+  await knex.schema.alterTable("Reminder", (table) => {
+    table.string("description").alter();
+  });
+  await knex.schema.alterTable("Question", (table) => {
+    table.string("question").alter();
+  });
+}


### PR DESCRIPTION
Changes schema for reminders and questions to use variable length strings, addressing #32.